### PR TITLE
fix(search): resolve OpenSubtitles initialization and improve mock source with realistic URLs

### DIFF
--- a/swahili_subtitle_translator/search/engine.py
+++ b/swahili_subtitle_translator/search/engine.py
@@ -50,8 +50,13 @@ class SubtitleSearchEngine:
     def _initialize_sources(self, opensubtitles_api_key: Optional[str] = None):
         """Initialize all available subtitle sources."""
         try:
-            self.sources[SourceType.OPENSUBTITLES] = OpenSubtitlesSource(opensubtitles_api_key)
-            logger.info("OpenSubtitles source initialized")
+            # Use API if key is provided, otherwise fallback to web scraping
+            use_api = bool(opensubtitles_api_key)
+            self.sources[SourceType.OPENSUBTITLES] = OpenSubtitlesSource(
+                api_key=opensubtitles_api_key, 
+                use_api=use_api
+            )
+            logger.info(f"OpenSubtitles source initialized (API: {use_api})")
         except Exception as e:
             logger.warning(f"Failed to initialize OpenSubtitles source: {e}")
         


### PR DESCRIPTION


- Fix OpenSubtitles source constructor argument mismatch by properly passing api_key and use_api parameters
- Remove duplicate OpenSubtitles class that was incorrectly implementing Subscene functionality
- Make mock source completely generic and dynamic, generating results based on actual search queries
- Generate realistic OpenSubtitles.org URLs that actually work when clicked
- Improve TV show detection and dynamic episode generation
- Remove hardcoded content and make mock source work for any title/query
- Add proper URL slug generation for realistic OpenSubtitles search URLs
- Fix SearchResult constructor calls to remove invalid display_name parameter
- Improve retry logic with exponential backoff for real sources facing 403 errors

Now provides:
- Functional OpenSubtitles source initialization (4 sources total)
- Dynamic mock results: 'Avatar' → realistic Avatar subtitle results
- Working URLs: https://www.opensubtitles.org/en/search/sublanguageid-all/moviename-{title}
- Proper handling of both movies and TV shows in mock source

Fixes: #search-engine-initialization-issues